### PR TITLE
Widget tsdoc tags

### DIFF
--- a/packages/plugin-scripts/package.json
+++ b/packages/plugin-scripts/package.json
@@ -22,6 +22,9 @@
         "dist"
     ],
     "scripts": {
+        "build": "tsc",
+        "pretest": "npm run build",
+        "test": "mocha \"dist/__tests__/**/*.unit.js\"",
         "release": "commit-and-tag-version -t plugin-scripts@ --releaseCommitMessageFormat \"chore(release): plugin-scripts@{{currentTag}} [skip ci]\"",
         "predeploy": "cp ../../LICENSE .",
         "deploy": "npm publish --access=public"
@@ -29,10 +32,23 @@
     "author": "System Automation Corp.",
     "license": "MIT",
     "dependencies": {
+        "@microsoft/tsdoc": "^0.14.2",
+        "comment-parser": "^1.3.1",
+        "glob": "^10.2.1",
         "jszip": "^3.10.0",
-        "mkdirp": "^3.0.0"
+        "lodash": "^4.17.21",
+        "mkdirp": "^3.0.0",
+        "typescript": "^5.0.4"
     },
     "devDependencies": {
-        "commit-and-tag-version": "^11.2.1"
+        "@types/chai": "^4.3.4",
+        "@types/chai-as-promised": "^7.1.5",
+        "@types/dirty-chai": "^2.0.2",
+        "@types/lodash": "^4.14.194",
+        "chai": "^4.3.7",
+        "chai-as-promised": "^7.1.1",
+        "commit-and-tag-version": "^11.2.1",
+        "dirty-chai": "^2.0.1",
+        "mocha": "^10.2.0"
     }
 }

--- a/packages/plugin-scripts/src/__tests__/manifest/badFiles/multipleWidgets/widget.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/badFiles/multipleWidgets/widget.tsx
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+/** @widget */
+export function Widget1() {
+    return null;
+}
+
+/** @widget */
+export function Widget2() {
+    return null;
+}

--- a/packages/plugin-scripts/src/__tests__/manifest/badFiles/notFunctionComponent/widget.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/badFiles/notFunctionComponent/widget.tsx
@@ -1,0 +1,5 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+/** @widget */
+export class NotFunctionComponent {}

--- a/packages/plugin-scripts/src/__tests__/manifest/scanner.unit.ts
+++ b/packages/plugin-scripts/src/__tests__/manifest/scanner.unit.ts
@@ -9,12 +9,14 @@ import { Scanner, WidgetDescriptor } from '../../manifest';
 
 chai.use(dirtyChai).use(chaiAsPromised);
 
+const Timeout = 15000;
+
 describe('Scanner', () => {
     const scanner = new Scanner('src/__tests__/manifest/testFiles', { defaultVersion: '1-test' });
     let widgets: Dictionary<WidgetDescriptor> = {};
 
     before(async function () {
-        this.timeout(5000);
+        this.timeout(Timeout);
 
         widgets = (await scanner.scan()).widgets;
     });
@@ -92,13 +94,13 @@ describe('Scanner', () => {
             await expect(scanner.scan()).to.be.rejectedWith(
                 'Multiple @widget declarations in src/__tests__/manifest/badFiles/multipleWidgets/widget.tsx, only the default export can be declared a widget',
             );
-        }).timeout(5000);
+        }).timeout(Timeout);
 
         it('fails if @widget is not on a function', async () => {
             const scanner = new Scanner('src/__tests__/manifest/badFiles/notFunctionComponent');
 
             await expect(scanner.scan()).to.be.rejectedWith('@widget must be declared on a FunctionComponent');
-        }).timeout(5000);
+        }).timeout(Timeout);
     });
 
     describe('props', () => {

--- a/packages/plugin-scripts/src/__tests__/manifest/scanner.unit.ts
+++ b/packages/plugin-scripts/src/__tests__/manifest/scanner.unit.ts
@@ -13,7 +13,9 @@ describe('Scanner', () => {
     const scanner = new Scanner('src/__tests__/manifest/testFiles', { defaultVersion: '1-test' });
     let widgets: Dictionary<WidgetDescriptor> = {};
 
-    before(async () => {
+    before(async function () {
+        this.timeout(5000);
+
         widgets = (await scanner.scan()).widgets;
     });
 

--- a/packages/plugin-scripts/src/__tests__/manifest/scanner.unit.ts
+++ b/packages/plugin-scripts/src/__tests__/manifest/scanner.unit.ts
@@ -1,0 +1,285 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import dirtyChai from 'dirty-chai';
+import { Dictionary } from 'lodash';
+import { Scanner, WidgetDescriptor } from '../../manifest';
+
+chai.use(dirtyChai).use(chaiAsPromised);
+
+describe('Scanner', () => {
+    const scanner = new Scanner('src/__tests__/manifest/testFiles', { defaultVersion: '1-test' });
+    let widgets: Dictionary<WidgetDescriptor> = {};
+
+    before(async () => {
+        widgets = (await scanner.scan()).widgets;
+    });
+
+    describe('widget', () => {
+        it('detects components marked with @widget', () => {
+            expect(widgets['Basic']).to.eql({
+                id: 'Basic',
+                name: 'Basic',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/basic.tsx',
+                properties: [],
+            });
+        });
+
+        it('detects components marked with @widgetName', () => {
+            expect(widgets['Basic2']).to.eql({
+                id: 'Basic2',
+                name: 'Basic2',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/basic2.tsx',
+                properties: [],
+            });
+        });
+
+        it('allows overriding widget id', () => {
+            expect(widgets['CustomId']).to.eql({
+                id: 'CustomId',
+                name: 'CustomId',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/widgetId.tsx',
+                properties: [],
+            });
+        });
+
+        it('allows setting widget name', () => {
+            expect(widgets['WidgetName']).to.eql({
+                id: 'WidgetName',
+                name: 'Test Widget Name',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/widgetName.tsx',
+                properties: [],
+            });
+        });
+
+        it('allows setting widget description', () => {
+            expect(widgets['WidgetDescription']).to.eql({
+                id: 'WidgetDescription',
+                name: 'WidgetDescription',
+                description: 'This is a sample description for a widget. It may wrap to multiple lines.',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/description.tsx',
+                properties: [],
+            });
+        });
+
+        it('allows overriding version for widget', () => {
+            expect(widgets['WidgetVersion']).to.eql({
+                id: 'WidgetVersion',
+                name: 'WidgetVersion',
+                description: '',
+                version: 'testVersion',
+                src: 'src/__tests__/manifest/testFiles/version.tsx',
+                properties: [],
+            });
+        });
+
+        it('fails if module contains multiple widgets', async () => {
+            const scanner = new Scanner('src/__tests__/manifest/badFiles/multipleWidgets');
+
+            await expect(scanner.scan()).to.be.rejectedWith(
+                'Multiple @widget declarations in src/__tests__/manifest/badFiles/multipleWidgets/widget.tsx, only the default export can be declared a widget',
+            );
+        }).timeout(5000);
+
+        it('fails if @widget is not on a function', async () => {
+            const scanner = new Scanner('src/__tests__/manifest/badFiles/notFunctionComponent');
+
+            await expect(scanner.scan()).to.be.rejectedWith('@widget must be declared on a FunctionComponent');
+        }).timeout(5000);
+    });
+
+    describe('props', () => {
+        it('detects properties through type reference', () => {
+            expect(widgets['PropsTypeReference']).to.eql({
+                id: 'PropsTypeReference',
+                name: 'PropsTypeReference',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/typeReferenceProps.tsx',
+                properties: [
+                    {
+                        name: 'textProperty',
+                        displayName: 'textProperty',
+                        type: 'text',
+                        optional: false,
+                    },
+                ],
+            });
+        });
+
+        it('detects properties on type literal', () => {
+            expect(widgets['PropsTypeLiteral']).to.eql({
+                id: 'PropsTypeLiteral',
+                name: 'PropsTypeLiteral',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/typeLiteralProps.tsx',
+                properties: [
+                    {
+                        name: 'textProperty',
+                        displayName: 'textProperty',
+                        type: 'text',
+                        optional: false,
+                    },
+                ],
+            });
+        });
+
+        xit('detects properties of intersection types', () => {
+            expect(widgets['PropsIntersectionType']).to.eql({
+                id: 'PropsIntersectionType',
+                name: 'PropsIntersectionType',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/intersectionTypeProps.tsx',
+                properties: [
+                    {
+                        name: 'base',
+                        displayName: 'base',
+                        type: 'text',
+                        optional: false,
+                    },
+                    {
+                        name: 'textProperty',
+                        displayName: 'textProperty',
+                        type: 'text',
+                        optional: false,
+                    },
+                ],
+            });
+        });
+
+        it('allows setting property name', () => {
+            expect(widgets['PropertyName']).to.eql({
+                id: 'PropertyName',
+                name: 'PropertyName',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/propertyName.tsx',
+                properties: [
+                    {
+                        name: 'textProperty',
+                        displayName: 'Text Property',
+                        type: 'text',
+                        optional: false,
+                    },
+                ],
+            });
+        });
+
+        it('allows overriding property type', () => {
+            expect(widgets['PropertyType']).to.eql({
+                id: 'PropertyType',
+                name: 'PropertyType',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/propertyType.tsx',
+                properties: [
+                    {
+                        name: 'choicesProperty',
+                        displayName: 'choicesProperty',
+                        type: 'choices',
+                        optional: false,
+                    },
+                ],
+            });
+        });
+
+        it('detects optional properties', () => {
+            expect(widgets['OptionalProperty']).to.eql({
+                id: 'OptionalProperty',
+                name: 'OptionalProperty',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/optionalProperty.tsx',
+                properties: [
+                    {
+                        name: 'textProperty',
+                        displayName: 'textProperty',
+                        type: 'text',
+                        optional: true,
+                    },
+                ],
+            });
+        });
+
+        it('detects properties that can be undefined', () => {
+            expect(widgets['OptionalProperty2']).to.eql({
+                id: 'OptionalProperty2',
+                name: 'OptionalProperty2',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/optionalProperty2.tsx',
+                properties: [
+                    {
+                        name: 'textProperty',
+                        displayName: 'textProperty',
+                        type: 'text',
+                        optional: true,
+                    },
+                ],
+            });
+        });
+
+        it('infers type of number properties', () => {
+            expect(widgets['NumberProperty']).to.eql({
+                id: 'NumberProperty',
+                name: 'NumberProperty',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/numberProperty.tsx',
+                properties: [
+                    {
+                        name: 'numProperty',
+                        displayName: 'numProperty',
+                        type: 'number',
+                        optional: false,
+                    },
+                ],
+            });
+        });
+
+        xit('infers type of record properties', () => {
+            expect(widgets['RecordProperty']).to.eql({
+                id: 'RecordProperty',
+                name: 'RecordProperty',
+                description: '',
+                version: '1-test',
+                src: 'src/__tests__/manifest/testFiles/recordProperty.tsx',
+                properties: [
+                    {
+                        name: 'recordProperty',
+                        displayName: 'recordProperty',
+                        type: 'inputGroup',
+                        optional: false,
+                        inputGroup: [
+                            {
+                                name: 'nested1',
+                                displayName: 'nested1',
+                                type: 'text',
+                                optional: false,
+                            },
+                            {
+                                name: 'nested2',
+                                displayName: 'nested2',
+                                type: 'number',
+                                optional: false,
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/basic.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/basic.tsx
@@ -1,0 +1,9 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+/** @widget */
+function Basic() {
+    return null;
+}
+
+export default Basic;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/basic2.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/basic2.tsx
@@ -1,0 +1,9 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+/** @widgetName */
+function Basic2() {
+    return null;
+}
+
+export default Basic2;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/description.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/description.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+/**
+ * This is a sample description for a widget. It may wrap to
+ * multiple lines.
+ *
+ * @widget
+ */
+function WidgetDescription() {
+    return null;
+}
+
+export default WidgetDescription;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/intersectionTypeProps.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/intersectionTypeProps.tsx
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+type BaseType = {
+    base: string;
+};
+
+type PropsType = BaseType & {
+    textProperty: string;
+};
+
+/** @widget */
+function PropsIntersectionType(props: PropsType) {
+    return null;
+}
+
+export default PropsIntersectionType;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/numberProperty.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/numberProperty.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+type PropsType = {
+    numProperty: number;
+};
+
+/** @widget */
+function NumberProperty(props: PropsType) {
+    return null;
+}
+
+export default NumberProperty;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/optionalProperty.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/optionalProperty.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+type PropsType = {
+    textProperty?: string;
+};
+
+/** @widget */
+function OptionalProperty(props: PropsType) {
+    return null;
+}
+
+export default OptionalProperty;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/optionalProperty2.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/optionalProperty2.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+type PropsType = {
+    textProperty: string | undefined;
+};
+
+/** @widget */
+function OptionalProperty2(props: PropsType) {
+    return null;
+}
+
+export default OptionalProperty2;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/propertyName.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/propertyName.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+type PropsType = {
+    /**
+     * @propertyName Text Property
+     */
+    textProperty: string;
+};
+
+/** @widget */
+function PropertyName(props: PropsType) {
+    return null;
+}
+
+export default PropertyName;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/propertyType.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/propertyType.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+type PropsType = {
+    /**
+     * @propertyType choices
+     */
+    choicesProperty: string;
+};
+
+/** @widget */
+function PropertyType(props: PropsType) {
+    return null;
+}
+
+export default PropertyType;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/recordProperty.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/recordProperty.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+type PropsType = {
+    recordProperty: {
+        nested1: string;
+        nested2: number;
+    };
+};
+
+/** @widget */
+function RecordProperty(props: PropsType) {
+    return null;
+}
+
+export default RecordProperty;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/typeLiteralProps.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/typeLiteralProps.tsx
@@ -1,0 +1,9 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+/** @widget */
+function PropsTypeLiteral(props: { textProperty: string }) {
+    return null;
+}
+
+export default PropsTypeLiteral;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/typeReferenceProps.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/typeReferenceProps.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+type PropsType = {
+    textProperty: string;
+};
+
+/** @widget */
+function PropsTypeReference(props: PropsType) {
+    return null;
+}
+
+export default PropsTypeReference;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/version.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/version.tsx
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+/**
+ * @widget
+ * @widgetVersion testVersion
+ * */
+function WidgetVersion() {
+    return null;
+}
+
+export default WidgetVersion;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/widgetId.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/widgetId.tsx
@@ -1,0 +1,9 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+/** @widget CustomId */
+function Widget() {
+    return null;
+}
+
+export default Widget;

--- a/packages/plugin-scripts/src/__tests__/manifest/testFiles/widgetName.tsx
+++ b/packages/plugin-scripts/src/__tests__/manifest/testFiles/widgetName.tsx
@@ -1,0 +1,9 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+/** @widgetName Test Widget Name */
+function WidgetName() {
+    return null;
+}
+
+export default WidgetName;

--- a/packages/plugin-scripts/src/index.ts
+++ b/packages/plugin-scripts/src/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+export * from './manifest';

--- a/packages/plugin-scripts/src/manifest/debug.ts
+++ b/packages/plugin-scripts/src/manifest/debug.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+import _debug from 'debug';
+
+const debug = _debug('plugin-scripts:manifest');
+
+export default debug;

--- a/packages/plugin-scripts/src/manifest/descriptors.ts
+++ b/packages/plugin-scripts/src/manifest/descriptors.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+export type WidgetDescriptor = {
+    id: string;
+    name: string;
+    description?: string;
+    version?: string;
+    src: string;
+    properties: WidgetPropertyDescriptor[];
+};
+
+export type WidgetPropertyDescriptor = {
+    name: string;
+    displayName: string;
+    type: string;
+    optional?: boolean;
+    [key: string]: unknown;
+};

--- a/packages/plugin-scripts/src/manifest/descriptors.ts
+++ b/packages/plugin-scripts/src/manifest/descriptors.ts
@@ -12,8 +12,8 @@ export type WidgetDescriptor = {
 
 export type WidgetPropertyDescriptor = {
     name: string;
-    displayName: string;
+    displayName?: string;
     type: string;
-    optional?: boolean;
+    isOptional?: boolean;
     [key: string]: unknown;
 };

--- a/packages/plugin-scripts/src/manifest/errors.ts
+++ b/packages/plugin-scripts/src/manifest/errors.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+import { Node } from 'typescript';
+
+export function locationString(compilerNode: Node) {
+    const sourceFile = compilerNode.getSourceFile();
+    const location = sourceFile.getLineAndCharacterOfPosition(compilerNode.pos);
+
+    return `${sourceFile.fileName}(${location.line + 1},${location.character + 1})`;
+}
+
+export class SyntaxError extends Error {
+    constructor(message: string, compilerNode: Node) {
+        super(`${locationString(compilerNode)}: ${message}`);
+    }
+}

--- a/packages/plugin-scripts/src/manifest/fileScanner.ts
+++ b/packages/plugin-scripts/src/manifest/fileScanner.ts
@@ -1,0 +1,262 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+import { Spec } from 'comment-parser';
+import {
+    FunctionDeclaration,
+    Program,
+    PropertySignature,
+    SyntaxKind,
+    TypeElement,
+    TypeLiteralNode,
+    TypeNode,
+    TypeReferenceNode,
+    UnionTypeNode,
+} from 'typescript';
+import debug from './debug';
+import { WidgetDescriptor, WidgetPropertyDescriptor } from './descriptors';
+import { SyntaxError, locationString } from './errors';
+import { Comment, ParsedSource, parseFile } from './parser';
+
+export type FileScannerOptions = {
+    defaultVersion?: string;
+};
+
+export class FileScanner {
+    private parsedSource: ParsedSource | undefined;
+
+    constructor(private program: Program, private file: string, private options?: FileScannerOptions) {}
+
+    scanForWidget() {
+        const parsed = parseFile(this.program, this.file);
+        let widget: WidgetDescriptor | undefined;
+
+        if (parsed) {
+            this.parsedSource = parsed;
+
+            const widgetDeclarations = parsed.comments.filter(this.hasWidgetModifier);
+
+            if (widgetDeclarations.length > 1) {
+                throw new SyntaxError(
+                    `Multiple @widget declarations in ${this.file}, only the default export can be declared a widget`,
+                    widgetDeclarations[1].compilerNode,
+                );
+            } else if (widgetDeclarations.length === 1) {
+                debug('found @widget declaration in %s', this.file);
+
+                widget = this.processWidget(widgetDeclarations[0]);
+            }
+        }
+
+        return widget;
+    }
+
+    private hasWidgetModifier(comment: Comment) {
+        return comment.commentBlock.tags.some((tag) => tag.tag === 'widget' || tag.tag === 'widgetName');
+    }
+
+    private getTagValue(tags: Spec[], tagName: string, fullText?: boolean) {
+        const tag = tags.find((tag) => tag.tag === tagName);
+
+        if (!tag) {
+            return undefined;
+        }
+
+        const nameComponents = [tag.name];
+
+        if (fullText && tag.description) {
+            nameComponents.push(tag.description);
+        }
+
+        return nameComponents.join(' ');
+    }
+
+    private processWidget(widgetDeclaration: Comment) {
+        if (widgetDeclaration.compilerNode.kind !== SyntaxKind.FunctionDeclaration) {
+            throw new SyntaxError('@widget must be declared on a FunctionComponent', widgetDeclaration.compilerNode);
+        }
+
+        const funcDeclaration = widgetDeclaration.compilerNode as FunctionDeclaration;
+        const tags = widgetDeclaration.commentBlock.tags;
+        const widgetId = this.getTagValue(tags, 'widget') || funcDeclaration.name?.text;
+
+        if (!widgetId) {
+            throw new SyntaxError(
+                'Unable to determine widget id, no explicit id provided and unable to determine function name',
+                funcDeclaration,
+            );
+        }
+
+        const widgetName = this.getTagValue(tags, 'widgetName', true) || widgetId;
+        const widgetVersion = this.getTagValue(tags, 'widgetVersion') || this.options?.defaultVersion;
+
+        const widget: WidgetDescriptor = {
+            id: widgetId,
+            name: widgetName,
+            description: widgetDeclaration.commentBlock.description,
+            version: widgetVersion,
+            src: this.file,
+            properties: [],
+        };
+
+        const propsType = this.getPropsType(funcDeclaration);
+
+        if (propsType) {
+            widget.properties = this.processProperties(propsType);
+        }
+
+        return widget;
+    }
+
+    private processProperties(propsType: TypeLiteralNode) {
+        const properties: WidgetPropertyDescriptor[] = [];
+
+        for (const member of propsType.members) {
+            const name = member.name;
+
+            if (!name) {
+                throw new SyntaxError('Property has no name', member);
+            }
+
+            if (!('text' in name)) {
+                throw new SyntaxError('Unable to determine property id', member);
+            }
+
+            const comment = this.getPropertyComment(member);
+            const tags = comment?.commentBlock.tags ?? [];
+
+            const propertyId = name.text;
+            const propertyName = this.getTagValue(tags, 'propertyName', true) || propertyId;
+            const propertyType =
+                this.getTagValue(tags, 'propertyType') || this.determinePropertyType(propertyId, member);
+
+            properties.push({
+                name: propertyId,
+                displayName: propertyName,
+                type: propertyType,
+                optional: this.isPropertyOptional(member),
+            });
+        }
+
+        return properties;
+    }
+
+    private getPropertyComment(property: TypeElement) {
+        return this.parsedSource?.comments?.find((comment) => comment.compilerNode === property);
+    }
+
+    private determinePropertyType(id: string, property: TypeElement) {
+        // Default to text unless we can determine a better type;
+        let type = 'text';
+
+        const baseType = this.determineBaseType(property);
+
+        switch (baseType?.kind) {
+            case SyntaxKind.StringKeyword:
+                type = 'text';
+                break;
+
+            case SyntaxKind.NumberKeyword:
+                type = 'number';
+                break;
+
+            case SyntaxKind.BooleanKeyword:
+                type = 'boolean';
+                break;
+
+            default:
+                console.log(
+                    `${locationString(property)}: not able to infer type for property ${id}, defaulting to 'text'`,
+                );
+                break;
+        }
+
+        return type;
+    }
+
+    private determineBaseType(property: TypeElement) {
+        let typeNode: TypeNode | undefined;
+
+        if (property.kind === SyntaxKind.PropertySignature) {
+            typeNode = (property as PropertySignature).type;
+        }
+
+        if (typeNode?.kind === SyntaxKind.UnionType) {
+            const unionType = typeNode as UnionTypeNode;
+
+            // Remove undefined and null.
+            const types = unionType.types.filter(
+                (type) => type.kind !== SyntaxKind.UndefinedKeyword && type.kind !== SyntaxKind.NullKeyword,
+            );
+
+            if (types.length === 1) {
+                typeNode = types[0];
+            } else {
+                debug('');
+            }
+        }
+
+        return typeNode;
+    }
+
+    private isPropertyOptional(property: TypeElement) {
+        if (property.questionToken) {
+            return true;
+        }
+
+        if (property.kind === SyntaxKind.PropertySignature) {
+            const typeNode = (property as PropertySignature).type;
+
+            if (typeNode?.kind === SyntaxKind.UnionType) {
+                const unionType = typeNode as UnionTypeNode;
+
+                return unionType.types.some((type) => type.kind === SyntaxKind.UndefinedKeyword);
+            }
+        }
+
+        return false;
+    }
+
+    private getPropsType(funcDeclaration: FunctionDeclaration) {
+        const propsParam = funcDeclaration.parameters[0];
+        let propsType: TypeLiteralNode | undefined;
+
+        switch (propsParam?.type?.kind) {
+            case SyntaxKind.TypeLiteral:
+                propsType = propsParam.type as TypeLiteralNode;
+                break;
+
+            case SyntaxKind.TypeReference: {
+                const name = (propsParam.type as TypeReferenceNode).typeName;
+
+                if ('text' in name) {
+                    propsType = this.parsedSource?.types[name.text];
+                } else {
+                    throw new SyntaxError(
+                        'Unable to determine widget props type (qualified type references not supported)',
+                        propsParam.type,
+                    );
+                }
+
+                break;
+            }
+
+            default:
+                if (propsParam?.type?.kind) {
+                    throw new SyntaxError(
+                        `Unable to determine widget props type from ${SyntaxKind[propsParam.type.kind]}`,
+                        propsParam.type,
+                    );
+                }
+
+                // Only an error if there is a parameter.
+                if (propsParam) {
+                    throw new SyntaxError('No type specified for widget props', propsParam);
+                }
+
+                break;
+        }
+
+        return propsType;
+    }
+}

--- a/packages/plugin-scripts/src/manifest/index.ts
+++ b/packages/plugin-scripts/src/manifest/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+export * from './descriptors';
+export * from './errors';
+export * from './fileScanner';
+export * from './scanner';

--- a/packages/plugin-scripts/src/manifest/parser.ts
+++ b/packages/plugin-scripts/src/manifest/parser.ts
@@ -1,0 +1,175 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+import * as tsdoc from '@microsoft/tsdoc';
+import { Block, parse as parseComment } from 'comment-parser';
+import ts, { SourceFile, SyntaxKind, TypeAliasDeclaration } from 'typescript';
+import debug from './debug';
+
+// Adapted from @microsoft/tsdoc api-demo
+// https://github.com/microsoft/tsdoc/tree/main/api-demo
+
+export interface Comment {
+    compilerNode: ts.Node;
+    commentBlock: Block;
+}
+
+export type ParsedSource = {
+    sourceFile: SourceFile;
+    comments: Comment[];
+    types: {
+        [key: string]: ts.TypeLiteralNode;
+    };
+};
+
+/**
+ * Returns true if the specified SyntaxKind is part of a declaration form.
+ *
+ * Based on ts.isDeclarationKind() from the compiler.
+ * https://github.com/microsoft/TypeScript/blob/v3.0.3/src/compiler/utilities.ts#L6382
+ */
+function isDeclarationKind(kind: ts.SyntaxKind): boolean {
+    return (
+        kind === ts.SyntaxKind.ArrowFunction ||
+        kind === ts.SyntaxKind.BindingElement ||
+        kind === ts.SyntaxKind.ClassDeclaration ||
+        kind === ts.SyntaxKind.ClassExpression ||
+        kind === ts.SyntaxKind.Constructor ||
+        kind === ts.SyntaxKind.EnumDeclaration ||
+        kind === ts.SyntaxKind.EnumMember ||
+        kind === ts.SyntaxKind.ExportSpecifier ||
+        kind === ts.SyntaxKind.FunctionDeclaration ||
+        kind === ts.SyntaxKind.FunctionExpression ||
+        kind === ts.SyntaxKind.GetAccessor ||
+        kind === ts.SyntaxKind.ImportClause ||
+        kind === ts.SyntaxKind.ImportEqualsDeclaration ||
+        kind === ts.SyntaxKind.ImportSpecifier ||
+        kind === ts.SyntaxKind.InterfaceDeclaration ||
+        kind === ts.SyntaxKind.JsxAttribute ||
+        kind === ts.SyntaxKind.MethodDeclaration ||
+        kind === ts.SyntaxKind.MethodSignature ||
+        kind === ts.SyntaxKind.ModuleDeclaration ||
+        kind === ts.SyntaxKind.NamespaceExportDeclaration ||
+        kind === ts.SyntaxKind.NamespaceImport ||
+        kind === ts.SyntaxKind.Parameter ||
+        kind === ts.SyntaxKind.PropertyAssignment ||
+        kind === ts.SyntaxKind.PropertyDeclaration ||
+        kind === ts.SyntaxKind.PropertySignature ||
+        kind === ts.SyntaxKind.SetAccessor ||
+        kind === ts.SyntaxKind.ShorthandPropertyAssignment ||
+        kind === ts.SyntaxKind.TypeAliasDeclaration ||
+        kind === ts.SyntaxKind.TypeParameter ||
+        kind === ts.SyntaxKind.VariableDeclaration ||
+        kind === ts.SyntaxKind.JSDocTypedefTag ||
+        kind === ts.SyntaxKind.JSDocCallbackTag ||
+        kind === ts.SyntaxKind.JSDocPropertyTag
+    );
+}
+
+/**
+ * Retrieves the JSDoc-style comments associated with a specific AST node.
+ *
+ * Based on ts.getJSDocCommentRanges() from the compiler.
+ * https://github.com/microsoft/TypeScript/blob/v3.0.3/src/compiler/utilities.ts#L924
+ */
+function getJSDocCommentRanges(node: ts.Node, text: string): ts.CommentRange[] {
+    const commentRanges: ts.CommentRange[] = [];
+
+    switch (node.kind) {
+        case ts.SyntaxKind.Parameter:
+        case ts.SyntaxKind.TypeParameter:
+        case ts.SyntaxKind.FunctionExpression:
+        case ts.SyntaxKind.ArrowFunction:
+        case ts.SyntaxKind.ParenthesizedExpression:
+            commentRanges.push(...(ts.getTrailingCommentRanges(text, node.pos) || []));
+            break;
+    }
+    commentRanges.push(...(ts.getLeadingCommentRanges(text, node.pos) || []));
+
+    // True if the comment starts with '/**' but not if it is '/**/'
+    return commentRanges.filter(
+        (comment) =>
+            text.charCodeAt(comment.pos + 1) === 0x2a /* ts.CharacterCodes.asterisk */ &&
+            text.charCodeAt(comment.pos + 2) === 0x2a /* ts.CharacterCodes.asterisk */ &&
+            text.charCodeAt(comment.pos + 3) !== 0x2f /* ts.CharacterCodes.slash */,
+    );
+}
+
+function walkCompilerAst(node: ts.Node, comments: Comment[], types: ParsedSource['types']): void {
+    // The TypeScript AST doesn't store code comments directly.  If you want to find *every* comment,
+    // you would need to rescan the SourceFile tokens similar to how tsutils.forEachComment() works:
+    // https://github.com/ajafff/tsutils/blob/v3.0.0/util/util.ts#L453
+    //
+    // However, for this demo we are modeling a tool that discovers declarations and then analyzes their doc comments,
+    // so we only care about TSDoc that would conventionally be associated with an interesting AST node.
+
+    const buffer: string = node.getSourceFile().getFullText(); // don't use getText() here!
+
+    // Only consider nodes that are part of a declaration form.  Without this, we could discover
+    // the same comment twice (e.g. for a MethodDeclaration and its PublicKeyword).
+    if (isDeclarationKind(node.kind)) {
+        if (node.kind === SyntaxKind.TypeAliasDeclaration) {
+            const typeAlias = node as TypeAliasDeclaration;
+
+            if (typeAlias.type.kind === SyntaxKind.TypeLiteral) {
+                debug('discovered type %s', typeAlias.name.text);
+
+                types[typeAlias.name.text] = typeAlias.type as ts.TypeLiteralNode;
+            } else {
+                debug(
+                    'could not determine definition for type %s from %s',
+                    typeAlias.name.text,
+                    ts.SyntaxKind[typeAlias.type.kind],
+                );
+            }
+        }
+
+        // Find "/** */" style comments associated with this node.
+        // Note that this reinvokes the compiler's scanner -- the result is not cached.
+        const commentRanges: ts.CommentRange[] = getJSDocCommentRanges(node, buffer);
+
+        if (commentRanges.length > 0) {
+            for (const commentRange of commentRanges) {
+                const textRange = tsdoc.TextRange.fromStringRange(buffer, commentRange.pos, commentRange.end);
+                const blocks = parseComment(textRange.toString());
+
+                if (blocks.length) {
+                    comments.push({
+                        compilerNode: node,
+                        commentBlock: blocks[0], // there should only be one block in textRange
+                    });
+                }
+            }
+        }
+    }
+
+    return node.forEachChild((child) => walkCompilerAst(child, comments, types));
+}
+
+export function parseFile(program: ts.Program, file: string): ParsedSource | undefined {
+    debug('parsing file %s', file);
+
+    // This appears to be necessary to initialize some program state.  Without
+    // this the subsequent getSourceFile will fail.
+    program.getSemanticDiagnostics();
+
+    const sourceFile = program.getSourceFile(file);
+    sourceFile?.getLineAndCharacterOfPosition;
+
+    if (!sourceFile) {
+        debug('unable to get source file %s', file);
+
+        return undefined;
+    }
+
+    const comments: Comment[] = [];
+    const types: ParsedSource['types'] = {};
+
+    walkCompilerAst(sourceFile, comments, types);
+
+    return {
+        sourceFile,
+        comments,
+        types,
+    };
+}

--- a/packages/plugin-scripts/src/manifest/scanner.ts
+++ b/packages/plugin-scripts/src/manifest/scanner.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+import { glob } from 'glob';
+import { keyBy } from 'lodash';
+import ts from 'typescript';
+import { WidgetDescriptor } from './descriptors';
+import { FileScanner } from './fileScanner';
+
+export type ScannerOptions = {
+    defaultVersion?: string;
+};
+
+export class Scanner {
+    constructor(private sourceRoot: string, private options?: ScannerOptions) {}
+
+    async scan() {
+        const files = await glob(`${this.sourceRoot}/**/*.{ts,tsx}`);
+        const widgets: WidgetDescriptor[] = [];
+        const program = ts.createProgram(files, {});
+
+        for (const file of files) {
+            const fileScanner = new FileScanner(program, file, this.options);
+            const widget = fileScanner.scanForWidget();
+
+            if (widget) {
+                widgets.push(widget);
+            }
+        }
+
+        return {
+            widgets: keyBy(widgets, (widget) => widget.id),
+        };
+    }
+}

--- a/packages/plugin-scripts/tsconfig.json
+++ b/packages/plugin-scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json.schemastore.org/tsconfig",
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src"
+    },
+    "include": ["src"]
+}

--- a/packages/plugin/src/generators/app/templates/package.json
+++ b/packages/plugin/src/generators/app/templates/package.json
@@ -38,10 +38,11 @@
     },
     "scripts": {
         "start": "webpack-cli serve",
+        "prebuild": "manifestgen",
         "build": "webpack --mode production",
         "serve": "serve dist -p 3000",
         "clean": "rm -rf dist",
-        "prepackage": "manifestgen && npm run build",
+        "prepackage": "npm run build",
         "package": "pkgplugin",
         "storybook": "storybook dev -p 6006",
         "build-storybook": "storybook build"

--- a/packages/plugin/src/generators/app/templates/webpack.config.js
+++ b/packages/plugin/src/generators/app/templates/webpack.config.js
@@ -1,6 +1,3 @@
-// Copyright (c) 2023 System Automation Corporation.
-// This file is licensed under the MIT License.
-
 const ModuleFederationPlugin = require('webpack').container.ModuleFederationPlugin;
 const manifest = require('./dist/manifest.json');
 const path = require('path');

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,6 +532,11 @@
   resolved "https://registry.npmjs.org/@js-joda/locale_en-us/-/locale_en-us-3.2.2.tgz#e953add780a0b7ee32a81cdbeb15d80cc6c6b8cf"
   integrity sha512-/3KCf1BD0V9N5ffFCm7Q4VpWHty8hABAdtkIoyCf2VjxAYelTebw7Vq6L1rtrMyWU2Ltb7n00S1FWb5dewNjHg==
 
+"@microsoft/tsdoc@^0.14.2":
+  version "0.14.2"
+  resolved "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
+  integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
+
 "@mui/base@5.0.0-alpha.122":
   version "5.0.0-alpha.122"
   resolved "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.122.tgz#707c33834cfb627b81c273a25d50b2bef44a1256"
@@ -950,6 +955,11 @@
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
 
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
 "@popperjs/core@^2.11.6", "@popperjs/core@^2.11.7":
   version "2.11.7"
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz#ccab5c8f7dc557a52ca3288c10075c9ccd37fff7"
@@ -1047,6 +1057,18 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
+"@types/chai-as-promised@*", "@types/chai-as-promised@^7.1.5":
+  version "7.1.5"
+  resolved "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz#6e016811f6c7a64f2eed823191c3a6955094e255"
+  integrity sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz#e913e8175db8307d78b4e8fa690408ba6b65dee4"
+  integrity sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==
+
 "@types/debug@*":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
@@ -1058,6 +1080,14 @@
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@types/diff/-/diff-5.0.2.tgz#dd565e0086ccf8bc6522c6ebafd8a3125c91c12b"
   integrity sha512-uw8eYMIReOwstQ0QKF0sICefSy8cNO/v7gOTiIy9SbwuHyEecJUm7qlgueOO5S1udZ5I/irVydHVwMchgzbKTg==
+
+"@types/dirty-chai@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/@types/dirty-chai/-/dirty-chai-2.0.2.tgz#eeac4802329a41ed7815ac0c1a6360335bf77d0c"
+  integrity sha512-BruwIN/UQEU0ePghxEX+OyjngpOfOUKJQh3cmfeq2h2Su/g001iljVi3+Y2y2EFp3IPgjf4sMrRU33Hxv1FUqw==
+  dependencies:
+    "@types/chai" "*"
+    "@types/chai-as-promised" "*"
 
 "@types/ejs@*":
   version "3.1.2"
@@ -1089,6 +1119,11 @@
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
+"@types/lodash@^4.14.194":
+  version "4.14.194"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
+  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
 
 "@types/mem-fs-editor@*":
   version "7.0.2"
@@ -1568,6 +1603,11 @@ asap@^2.0.0:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -1776,6 +1816,26 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
+chai@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
+  integrity sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^4.1.2"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
@@ -1802,6 +1862,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 chokidar@3.5.3:
   version "3.5.3"
@@ -1868,7 +1933,7 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
-cliui@^7.0.2:
+cliui@^7.0.2, cliui@^7.0.4:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
   integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
@@ -1987,6 +2052,11 @@ commander@^9.0.0:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
   integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
+
+comment-parser@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
+  integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
 
 commit-and-tag-version@^11.2.1:
   version "11.2.1"
@@ -2271,7 +2341,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -2329,6 +2399,13 @@ decamelize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
+
+deep-eql@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
+  integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -2406,6 +2483,11 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+dirty-chai@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz#6b2162ef17f7943589da840abc96e75bda01aff3"
+  integrity sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -2815,6 +2897,14 @@ follow-redirects@^1.15.0:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+foreground-child@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz#1d173e776d75d2772fed08efe4a0de1ea1b12d0d"
+  integrity sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^4.0.1"
+
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -2888,6 +2978,11 @@ get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
 
 get-pkg-repo@^4.0.0:
   version "4.2.1"
@@ -2970,6 +3065,18 @@ glob@7.2.0:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.npmjs.org/glob/-/glob-10.2.1.tgz#44288e9186b5cd5baa848728533ba21a94aa8f33"
+  integrity sha512-ngom3wq2UhjdbmRE/krgkD8BQyi1KZ5l+D2dVm4+Yj+jJIBp74/ZGunL6gNGc/CYuQmvUBiavWEXIotRiv5R6A==
+  dependencies:
+    foreground-child "^3.1.0"
+    fs.realpath "^1.0.0"
+    jackspeak "^2.0.3"
+    minimatch "^9.0.0"
+    minipass "^5.0.0"
+    path-scurry "^1.7.0"
 
 glob@^7.0.0, glob@^7.0.5, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
@@ -3411,6 +3518,15 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+jackspeak@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/jackspeak/-/jackspeak-2.0.3.tgz#672eb397b97744a265b5862d7762b96e8dad6e61"
+  integrity sha512-0Jud3OMUdMbrlr3PyUMKESq51LXVAB+a239Ywdvd+Kgxj3MaBRml/nVRxf8tQFyfthMjuRkxkv7Vg58pmIMfuQ==
+  dependencies:
+    cliui "^7.0.4"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
 jake@^10.8.5:
   version "10.8.5"
   resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
@@ -3728,6 +3844,13 @@ loose-envify@^1.0.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^2.3.1:
+  version "2.3.6"
+  resolved "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz#76e4af498103c532d1ecc9be102036a21f787b53"
+  integrity sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==
+  dependencies:
+    get-func-name "^2.0.0"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -3739,6 +3862,11 @@ lru-cache@^7.7.1:
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
+lru-cache@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.0.tgz#19efafa9d08d1c08eb8efd78876075f0b8b1b07b"
+  integrity sha512-qFXQEwchrZcMVen2uIDceR8Tii6kCJak5rzDStfEM0qA3YLMswaxIEZO0DhIbJ3aqaJiDjt+3crlplOb0tDtKQ==
 
 make-error@^1.1.1:
   version "1.3.6"
@@ -3915,6 +4043,13 @@ minimatch@^7.2.0:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz#bfc8e88a1c40ffd40c172ddac3decb8451503b56"
+  integrity sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
@@ -3999,6 +4134,11 @@ minipass@^4.0.0:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.5.tgz#9e0e5256f1e3513f8c34691dd68549e85b2c8ceb"
   integrity sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==
 
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
 minizlib@^2.0.0, minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
@@ -4028,7 +4168,7 @@ mkdirp@^3.0.0:
 
 mocha@^10.2.0:
   version "10.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
+  resolved "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
   integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
   dependencies:
     ansi-colors "4.1.1"
@@ -4533,6 +4673,14 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-scurry@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.7.0.tgz#99c741a2cfbce782294a39994d63748b5a24f6db"
+  integrity sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==
+  dependencies:
+    lru-cache "^9.0.0"
+    minipass "^5.0.0"
+
 path-to-regexp@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
@@ -4551,6 +4699,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
@@ -5055,6 +5208,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+signal-exit@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.1.tgz#96a61033896120ec9335d96851d902cc98f0ba2a"
+  integrity sha512-uUWsN4aOxJAS8KOuf3QMyFtgm1pkb6I+KRZbRF/ghdf5T7sM+B1lLLzPDxswUjkmHyxQAVzEgG35E3NzDM9GVw==
+
 sinon@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-10.0.1.tgz#0d1a13ecb86f658d15984f84273e57745b1f4c57"
@@ -5512,7 +5670,7 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-detect@4.0.8, type-detect@^4.0.8:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
@@ -5548,6 +5706,11 @@ typedarray@^0.0.6:
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
 "typescript@^4.6.4 || ^5.0.0", typescript@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+
+typescript@^5.0.4:
   version "5.0.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
   integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==


### PR DESCRIPTION
This is a proposal for a different method of describing widgets that doesn't involve editing a separate json file.  Instead the widget description is specified by using tsdoc @tags inline with the respective code.   A minimal description would just mark the widget function with the `@widget` tag:

```typescript
/** @widget */
function MyWidget(props: { title: string }) {
  ...
}
```

The manifest generation will detect the tsdoc tag and generate the following description:

```json
{
  "id": "MyWidget",
  "name": "MyWidget",
  ...
  "properties": [
    {
      "name": "title",
      "type": "text",
      ...
    }
  ]
}
```

Additional tags (`@widgetName`, `@propertyName`, `@propertyType`, etc.) can be used to fine tune the widget description.

This is not fully feature complete, but it should work for any widget that only requires simple props.  WidgetProperties.json can still be used instead, and any existing widgets making use of WidgetProperties.json will continue to use the json file.