### PR TITLE
fix: use current package name

### DIFF
--- a/packages/plugin/src/generators/app/templates/webpack.config.js
+++ b/packages/plugin/src/generators/app/templates/webpack.config.js
@@ -4,6 +4,7 @@
 const ModuleFederationPlugin = require('webpack').container.ModuleFederationPlugin;
 const manifest = require('./dist/manifest.json');
 const path = require('path');
+const packageJson = require('./package.json');
 
 const exposedWidgets = {};
 
@@ -49,10 +50,10 @@ module.exports = {
     },
     plugins: [
         new ModuleFederationPlugin({
-            name: '<%= projectName %>',
+            name: packageJson.name,
             filename: 'remoteEntry.js',
             library: {
-                name: '<%= projectName %>',
+                name: packageJson.name,
                 type: 'window',
             },
             exposes: exposedWidgets,


### PR DESCRIPTION
Make sure the module federation library name matches the project name by reading the current package name during the webpack build instead of using the name that was used when the project was created.