### PR TITLE
fix: don't target node

### DIFF
--- a/packages/plugin/src/generators/app/templates/webpack.config.js
+++ b/packages/plugin/src/generators/app/templates/webpack.config.js
@@ -10,7 +10,6 @@ for (const widget of manifest.widgets ?? []) {
 
 module.exports = {
     mode: 'development',
-    target: 'node',
     output: {
         library: {
             type: 'commonjs2',


### PR DESCRIPTION
Setting target to "node" causes webpack to include some require() statements in remoteEntry.js that fail in a browser environment. For payment gateways, it's sufficient to set the output library type to commonjs2 so they can be imported in a node environment. Widgets will continue to be exported in remoteEntry.js using library type "window" as configured by ModuleFederationPlugin.