### PR TITLE
feat: handle object sub-types

### DIFF
--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -68,7 +68,8 @@ const results = await applications.findInstances();
 
 ##### `get(options)`
 
-Get the object definition for this store's object.
+Get the object definition for this store's object. The returned object includes inherited properties and actions if
+this object is derived from another object.
 
 -   `options` _[object]_ - _optional_
     -   `sanitized` _[boolean]_

--- a/packages/context/src/objects/objects.ts
+++ b/packages/context/src/objects/objects.ts
@@ -6,9 +6,16 @@ import { useMemo } from 'react';
 import { ApiServices, Callback, useApiServices } from '../api/index.js';
 import { Filter } from './filters.js';
 
+export type BaseObjReference = {
+    objectId: string;
+    discriminatorValue: unknown;
+};
+
 export type Obj = {
     id: string;
     name: string;
+    typeDiscriminatorProperty?: string;
+    baseObject?: BaseObjReference;
     properties?: Property[];
     actions?: Action[];
 };
@@ -160,10 +167,10 @@ export class ObjectStore {
         };
 
         if (!cb) {
-            return this.services.get(`data/objects/${this.objectId}`, config);
+            return this.services.get(`data/objects/${this.objectId}/effective`, config);
         }
 
-        this.services.get(`data/objects/${this.objectId}`, config, cb);
+        this.services.get(`data/objects/${this.objectId}/effective`, config, cb);
     }
 
     findInstances<T extends ObjectInstance = ObjectInstance>(filter?: Filter): Promise<T[]>;

--- a/packages/context/src/tests/objects/objects.unit.ts
+++ b/packages/context/src/tests/objects/objects.unit.ts
@@ -25,7 +25,7 @@ describe('ObjectStore', () => {
         it('returns object', async () => {
             const stub = sinon.stub(apiServices, 'get') as unknown as SinonStub<[string], Promise<Obj>>;
 
-            stub.withArgs('data/objects/testObject').resolves({ id: 'testObject', name: 'Test Object' });
+            stub.withArgs('data/objects/testObject/effective').resolves({ id: 'testObject', name: 'Test Object' });
 
             const result = await objectStore.get();
 
@@ -35,7 +35,7 @@ describe('ObjectStore', () => {
         it('returns object in callback', (done) => {
             sinon
                 .stub(apiServices, 'get')
-                .withArgs('data/objects/testObject', sinon.match.any, sinon.match.func)
+                .withArgs('data/objects/testObject/effective', sinon.match.any, sinon.match.func)
                 .yields(null, { id: 'testObject', name: 'Test Object' });
 
             objectStore.get(


### PR DESCRIPTION
The ObjectStore returns the effective object, taking into account any properties and actions inherited from base objects.  For now, to get the raw object record without inherited data, you will need to make the appropriate api call.