### PR TITLE
fix: remove source maps

### DIFF
--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -7,6 +7,7 @@
         "target": "es6",
         "lib": ["DOM"],
         "module": "ESNext",
-        "jsx": "react-jsx"
+        "jsx": "react-jsx",
+        "sourceMap": false
     }
 }


### PR DESCRIPTION
Typescript source is not distributed with the package so the source maps don't point at anything.

Currently, including the source map directives causes React dev mode to keep popping up error messages because the source can't be found.