### PR TITLE
feat(CDR-1324): include root object id in effective object

### DIFF
--- a/packages/context/src/objects/objects.ts
+++ b/packages/context/src/objects/objects.ts
@@ -45,6 +45,8 @@ export type Obj = {
     actions?: Action[];
 };
 
+export type ObjWithRoot = Obj & { rootObjectId: string };
+
 export type PropertyType =
     | 'address'
     | 'array'
@@ -361,11 +363,11 @@ export class ObjectStore {
         private objectId: string,
     ) {}
 
-    get(options?: ObjectOptions): Promise<Obj>;
-    get(cb?: Callback<Obj>): void;
-    get(options: ObjectOptions, cb?: Callback<Obj>): void;
+    get(options?: ObjectOptions): Promise<ObjWithRoot>;
+    get(cb?: Callback<ObjWithRoot>): void;
+    get(options: ObjectOptions, cb?: Callback<ObjWithRoot>): void;
 
-    get(optionsOrCallback?: ObjectOptions | Callback<Obj>, cb?: Callback<Obj>) {
+    get(optionsOrCallback?: ObjectOptions | Callback<ObjWithRoot>, cb?: Callback<ObjWithRoot>) {
         let options: ObjectOptions | undefined;
 
         if (cb) {

--- a/packages/context/src/tests/objects/objects.unit.ts
+++ b/packages/context/src/tests/objects/objects.unit.ts
@@ -5,7 +5,7 @@ import chai, { expect } from 'chai';
 import dirtyChai from 'dirty-chai';
 import sinon, { SinonStub } from 'sinon';
 import { ApiServices } from '../../api';
-import { Obj, ObjectStore } from '../../objects/index.js';
+import { ObjWithRoot, ObjectStore } from '../../objects/index.js';
 import { assertionCallback } from '../helpers.js';
 
 chai.use(dirtyChai);
@@ -23,24 +23,28 @@ describe('ObjectStore', () => {
 
     context('#get', () => {
         it('returns object', async () => {
-            const stub = sinon.stub(apiServices, 'get') as unknown as SinonStub<[string], Promise<Obj>>;
+            const stub = sinon.stub(apiServices, 'get') as unknown as SinonStub<[string], Promise<ObjWithRoot>>;
 
-            stub.withArgs('data/objects/testObject/effective').resolves({ id: 'testObject', name: 'Test Object' });
+            stub.withArgs('data/objects/testObject/effective').resolves({
+                id: 'testObject',
+                name: 'Test Object',
+                rootObjectId: 'testObject',
+            });
 
             const result = await objectStore.get();
 
-            expect(result).to.eql({ id: 'testObject', name: 'Test Object' });
+            expect(result).to.eql({ id: 'testObject', name: 'Test Object', rootObjectId: 'testObject' });
         });
 
         it('returns object in callback', (done) => {
             sinon
                 .stub(apiServices, 'get')
                 .withArgs('data/objects/testObject/effective', sinon.match.any, sinon.match.func)
-                .yields(null, { id: 'testObject', name: 'Test Object' });
+                .yields(null, { id: 'testObject', name: 'Test Object', rootObjectId: 'testObject' });
 
             objectStore.get(
                 assertionCallback(done, (result) => {
-                    expect(result).to.eql({ id: 'testObject', name: 'Test Object' });
+                    expect(result).to.eql({ id: 'testObject', name: 'Test Object', rootObjectId: 'testObject' });
                 }),
             );
         });


### PR DESCRIPTION
This PR adds the type `ObjWithRoot`, which is the same as `Obj` except that it includes an object's root object id. This property is now included when fetching effective objects.