### PR TITLE
fix: update widget properties for sample widget

### DIFF
--- a/packages/plugin/src/generators/app/templates/package.json
+++ b/packages/plugin/src/generators/app/templates/package.json
@@ -9,6 +9,7 @@
     },
     "devDependencies": {
         "@babel/core": "^7.17.0",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/preset-env": "^7.17.0",
         "@babel/preset-react": "^7.17.0",
         "@babel/preset-typescript": "^7.17.0",

--- a/packages/plugin/src/generators/app/templates/src/widgets/SampleWidget/WidgetProperties.json
+++ b/packages/plugin/src/generators/app/templates/src/widgets/SampleWidget/WidgetProperties.json
@@ -6,10 +6,10 @@
     "src": "src/widgets/SampleWidget",
     "properties": [
         {
-            "id": "message",
-            "name": "Message",
+            "name": "message",
             "type": "text",
-            "optional": true
+            "isOptional": true,
+            "inputLabel": "Message"
         }
     ]
 }

--- a/packages/plugin/src/generators/app/templates/src/widgets/SampleWidget/WidgetProperties.json
+++ b/packages/plugin/src/generators/app/templates/src/widgets/SampleWidget/WidgetProperties.json
@@ -9,7 +9,7 @@
             "name": "message",
             "type": "text",
             "isOptional": true,
-            "inputLabel": "Message"
+            "displayName": "Message"
         }
     ]
 }


### PR DESCRIPTION
The widget properties of the sample widget were not aligned with how the builder reads them. This fixes that and provides a better learning experience for new widget developers..