### PR TITLE
feat: add initialValue object type

### DIFF
--- a/widgetschema.json
+++ b/widgetschema.json
@@ -187,7 +187,7 @@
                     "type": "boolean"
                 },
                 "initialValue": {
-                    "oneOf": [{ "type": "string" }, { "type": "number" }, { "type": "boolean" }],
+                    "oneOf": [{ "type": "string" }, { "type": "number" }, { "type": "boolean" }, { "type": "object" }],
                     "description": "Initial value of the property"
                 },
                 "tooltip": {


### PR DESCRIPTION
Makes `initialValue` using an object type valid. 

Example
```json
{
    "name": "action",
    "type": "inputGroup",
    "displayName": "Action",
    "isOptional": true,
    "initialValue": {"label": "green", "favoriteColor": "yellow"}, // now valid
    "inputGroup": [
        {
            "type": "text",
            "name": "label",
            "displayName": "Text Color"
        },
        {
            "type": "text",
            "name": "label",
            "displayName": "Background Color"
        }
    ]
}
```