### PR TITLE
fix: fully specify import for useApiServices

### DIFF
--- a/packages/context/src/app/AppProvider.tsx
+++ b/packages/context/src/app/AppProvider.tsx
@@ -2,7 +2,7 @@
 // This file is licensed under the MIT License.
 
 import { createContext, ReactNode, useCallback, useContext } from 'react';
-import { useApiServices } from '../api';
+import { useApiServices } from '../api/index.js';
 import { Obj } from '../objects';
 import { AxiosError } from 'axios';
 

--- a/packages/context/src/app/AppProvider.tsx
+++ b/packages/context/src/app/AppProvider.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) 2023 System Automation Corporation.
 // This file is licensed under the MIT License.
 
+import { AxiosError } from 'axios';
 import { createContext, ReactNode, useCallback, useContext } from 'react';
 import { useApiServices } from '../api/index.js';
-import { Obj } from '../objects';
-import { AxiosError } from 'axios';
+import { Obj } from '../objects/index.js';
 
 export type AppType = 'public' | 'portal' | 'private';
 

--- a/packages/context/src/tests/objects/objects.unit.ts
+++ b/packages/context/src/tests/objects/objects.unit.ts
@@ -4,7 +4,7 @@
 import chai, { expect } from 'chai';
 import dirtyChai from 'dirty-chai';
 import sinon, { SinonStub } from 'sinon';
-import { ApiServices } from '../../api';
+import { ApiServices } from '../../api/index.js';
 import { ObjWithRoot, ObjectStore } from '../../objects/index.js';
 import { assertionCallback } from '../helpers.js';
 


### PR DESCRIPTION
The import of `useApiServices` in `AppProvider` did not contain a valid file extension. This was causing an issue where `useApiServices` would fail to resolve from `../api` when running `pkgplugin` for some custom widget projects.