### PR TITLE
feat: update ActionInput type to include additional properties

### DIFF
--- a/packages/context/src/objects/objects.ts
+++ b/packages/context/src/objects/objects.ts
@@ -361,6 +361,17 @@ export type ActionInput = {
         maxDocuments?: number;
         customMessage?: string;
     };
+    isAddressLine1?: boolean;
+    addressPropertyId?: string;
+    defaultPages?: Record<string, string>;
+    instance?: ObjectInstance;
+    properties?: Property[];
+    canUpdateProperty?: boolean;
+    allCriteriaInputs?: string[];
+    apiServices?: ApiServices;
+    middleObject: ObjWithRoot;
+    initialMiddleObjectInstances: ObjectInstance[];
+    getMiddleObjectInstances: () => Promise<ObjectInstance[]>;
     /**
      * An array of sub-components to be rendered inside sections.
      */


### PR DESCRIPTION
The ActionInput type mimics the FormIO component model. This PR adds the properties that were added to the FormIO custom components, but are missing from the ActionInput model.

Refs: CDR-2140