### PR TITLE
feat: add 'nonStrictEnum' to ActionInput model

### DIFF
--- a/packages/context/src/objects/objects.ts
+++ b/packages/context/src/objects/objects.ts
@@ -326,6 +326,7 @@ export type ActionInput = {
          */
         values?: SelectOption[];
     };
+    nonStrictEnum?: boolean;
     inputMask?: string;
     inputMaskPlaceholderChar?: string;
     tableView?: boolean;


### PR DESCRIPTION
The 'ActionInput' model replicates the FormIO input field model. Add 'nonStrictEnum' as a property there, so it can be used in the configuration of this property when the field is added to the form.

Refs: CDR-2238