### PR TITLE
Revert "feat: add 'nonStrictEnum' to ActionInput model"

### DIFF
--- a/packages/context/src/objects/objects.ts
+++ b/packages/context/src/objects/objects.ts
@@ -350,7 +350,6 @@ export type ActionInput = {
          */
         values?: SelectOption[];
     };
-    nonStrictEnum?: boolean;
     inputMask?: string;
     inputMaskPlaceholderChar?: string;
     tableView?: boolean;


### PR DESCRIPTION
Reverts Evoke-Platform/evoke-sdk#638

A new type will be added to the ui-component library with the additional properties on the `ActionInput` model that are used for internal implementation.