### PR TITLE
fix(CDR-2403): remove react-oidc-context from devDependencies to avoi…

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -56,7 +56,7 @@
         "msw": "^1.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.3.1",
-        "react-oidc-context": "^2.4.0",
+        "react-oidc-context": "^3.3.0",
         "react-router-dom": "^6.16.0",
         "sinon": "^18.0.0",
         "typescript": "^5.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -579,6 +579,17 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
+"@evoke-platform/context@^1.0.0", "@evoke-platform/context@^1.1.0-testing.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@evoke-platform/context/-/context-1.3.0.tgz#4ffd8ba8d1584a031e21a524406b35253af7a014"
+  integrity sha512-5OGCdhoO1sb4CNmGmSW7bxAKqMgP7qYpBA3TRTjNMj9cMK7TcIunpiziSX2tbUo92ZSlvis3KIwl/4Tj2CgccA==
+  dependencies:
+    "@isaacs/ttlcache" "^1.4.1"
+    "@microsoft/signalr" "^7.0.12"
+    axios "^1.7.9"
+    oidc-client-ts "^3.3.0"
+    uuid "^9.0.1"
+
 "@evoke-platform/ui-components@^1.3.0":
   version "1.3.0"
   resolved "https://registry.npmjs.org/@evoke-platform/ui-components/-/ui-components-1.3.0.tgz#e5c3ddf34a75402135f518b9d3e851de6d3edbe6"
@@ -2354,7 +2365,7 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axios@^1.11.0:
+axios@^1.11.0, axios@^1.7.9:
   version "1.11.0"
   resolved "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
   integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
@@ -7897,10 +7908,10 @@ react-number-format@^4.9.3:
   dependencies:
     prop-types "^15.7.2"
 
-react-oidc-context@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/react-oidc-context/-/react-oidc-context-2.4.0.tgz#751ff186af5e731702e35d8b46aa66b1351885d7"
-  integrity sha512-7xbEXlBBlWBQfdSibjeA7jC5w1oKTvZVAodd9A+fmqDRt4bD+gGODWgGT8dX+a0S96Vfo7lzIrEBP7eZCFkwWw==
+react-oidc-context@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/react-oidc-context/-/react-oidc-context-3.3.0.tgz#ccca8c25c7ba04ca4ec4e3b229b39c122100988f"
+  integrity sha512-302T/ma4AOVAxrHdYctDSKXjCq9KNHT564XEO2yOPxRfxEP58xa4nz+GQinNl8x7CnEXECSM5JEjQJk3Cr5BvA==
 
 react-property@2.0.2:
   version "2.0.2"


### PR DESCRIPTION
…d version conflicts

react-oidc-context should only be a peerDependency to ensure single authentication context consuming applications can now use any compatible version (>=2) without conflicts