### PR TITLE
fix: don't stringify arrays

### DIFF
--- a/packages/context/src/api/paramsSerializer.ts
+++ b/packages/context/src/api/paramsSerializer.ts
@@ -8,7 +8,13 @@ export function paramsSerializer(params: Record<string, unknown>, options?: Para
             continue;
         }
 
-        searchParams.append(key, typeof value !== 'string' ? JSON.stringify(value) : value);
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                searchParams.append(key, typeof item !== 'string' ? JSON.stringify(item) : item);
+            }
+        } else {
+            searchParams.append(key, typeof value !== 'string' ? JSON.stringify(value) : value);
+        }
     }
 
     return searchParams.toString();


### PR DESCRIPTION
The backend does not understand stringified arrays.  Instead send each array element as its own query param.