### PR TITLE
fix(CDR-3023): Use context processor for cache provider

### DIFF
--- a/packages/context/src/api/ApiCacheProvider.tsx
+++ b/packages/context/src/api/ApiCacheProvider.tsx
@@ -16,6 +16,12 @@ export type ApiCacheProviderProps = {
     ttlMs?: number;
 };
 
+/**
+ * Enables in-flight GET request deduplication for all `useApiServices` consumers wrapped
+ * by this provider. Concurrent requests to the same URL share a single network call, and
+ * the response is reused for `ttlMs` milliseconds (default 200ms) after it resolves.
+ * Without this provider, no deduplication occurs.
+ */
 export function ApiCacheProvider({ children, ttlMs = 200 }: ApiCacheProviderProps) {
     const cache = useRef<ApiCache>({
         inflightGets: new Map(),

--- a/packages/context/src/api/ApiCacheProvider.tsx
+++ b/packages/context/src/api/ApiCacheProvider.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 System Automation Corporation.
+// This file is licensed under the MIT License.
+
+import { ReactNode, createContext, useContext, useRef } from 'react';
+
+export type ApiCache = {
+    inflightGets: Map<string, Promise<unknown>>;
+    inflightTimers: Map<string, ReturnType<typeof setTimeout>>;
+    ttlMs: number;
+};
+
+export const ApiCacheContext = createContext<ApiCache | null>(null);
+
+export type ApiCacheProviderProps = {
+    children: ReactNode;
+    ttlMs?: number;
+};
+
+export function ApiCacheProvider({ children, ttlMs = 200 }: ApiCacheProviderProps) {
+    const cache = useRef<ApiCache>({
+        inflightGets: new Map(),
+        inflightTimers: new Map(),
+        ttlMs,
+    });
+
+    return <ApiCacheContext.Provider value={cache.current}>{children}</ApiCacheContext.Provider>;
+}
+
+export function useApiCache() {
+    return useContext(ApiCacheContext);
+}

--- a/packages/context/src/api/apiServices.ts
+++ b/packages/context/src/api/apiServices.ts
@@ -38,6 +38,7 @@ export class ApiServices {
         });
     }
 
+    // Reset the timer for deleting the cached GET request. If the timer expires, the cached request is removed from the inflightGets map.
     private resetDeleteTimer(cacheKey: string, request: Promise<AxiosResponse<unknown>>) {
         if (!this.cache) return;
 

--- a/packages/context/src/api/apiServices.ts
+++ b/packages/context/src/api/apiServices.ts
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { AuthenticationContext, useAuthenticationContext } from '../authentication/AuthenticationContextProvider.js';
 import { useApiBaseUrl } from './ApiBaseUrlProvider.js';
+import { ApiCache, useApiCache } from './ApiCacheProvider.js';
 import { Callback } from './callback.js';
 import { paramsSerializer } from './paramsSerializer.js';
 
@@ -13,18 +14,13 @@ export type Data = Record<string, unknown> | FormData | File;
 
 const sessionId = uuidv4();
 
-const GET_CACHE_TTL_MS = 200;
-
-// Map of inflight GET requests to their promises, keyed by URL (including baseURL)
-const inflightGets = new Map<string, Promise<AxiosResponse<unknown>>>();
-const inflightTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
 export class ApiServices {
     private readonly authId: string;
 
     constructor(
         private api: AxiosInstance,
         authContext?: AuthenticationContext,
+        private cache: ApiCache | null = null,
     ) {
         this.authId = authContext?.account.id ?? 'anon';
 
@@ -42,8 +38,10 @@ export class ApiServices {
         });
     }
 
-    // Reset the timer for deleting the cached GET request. If the timer expires, the cached request is removed from the inflightGets map.
     private resetDeleteTimer(cacheKey: string, request: Promise<AxiosResponse<unknown>>) {
+        if (!this.cache) return;
+
+        const { inflightGets, inflightTimers } = this.cache;
         const existing = inflightTimers.get(cacheKey);
         if (existing) clearTimeout(existing);
 
@@ -52,7 +50,7 @@ export class ApiServices {
                 inflightGets.delete(cacheKey);
             }
             inflightTimers.delete(cacheKey);
-        }, GET_CACHE_TTL_MS);
+        }, this.cache.ttlMs);
 
         inflightTimers.set(cacheKey, timer);
     }
@@ -86,16 +84,17 @@ export class ApiServices {
         }
 
         // Bypass cache when a custom paramsSerializer is provided since we can't guarantee that it will produce the same result
-        if (config?.paramsSerializer) {
+        if (!this.cache || config?.paramsSerializer) {
             return this.promiseOrCallback(this.api.get<T, AxiosResponse<T, D>>(url, config), cb);
         }
+
+        const { inflightGets, inflightTimers } = this.cache;
 
         // create unique cache key for the request based on the full URL (including baseURL) and serialized params
         const paramStr = config?.params ? paramsSerializer(config.params) : '';
         const cacheKey = `${this.authId}|${this.api.defaults.baseURL ?? ''}|${url}|${paramStr}`;
         let request = inflightGets.get(cacheKey) as Promise<AxiosResponse<T, D>> | undefined;
 
-        // If there's no inflight request for the same URL and params, create one and add it to the cache. Otherwise, reuse the existing request.
         if (!request) {
             request = this.api.get<T, AxiosResponse<T, D>>(url, config);
             inflightGets.set(cacheKey, request);
@@ -234,10 +233,11 @@ export class ApiServices {
 export function useApiServices() {
     const authContext = useAuthenticationContext();
     const baseURL = useApiBaseUrl();
+    const cache = useApiCache();
 
     const apiServices = useMemo(
-        () => new ApiServices(axios.create({ baseURL, paramsSerializer }), authContext),
-        [authContext, baseURL],
+        () => new ApiServices(axios.create({ baseURL, paramsSerializer }), authContext, cache),
+        [authContext, baseURL, cache],
     );
 
     return apiServices;

--- a/packages/context/src/api/index.ts
+++ b/packages/context/src/api/index.ts
@@ -3,5 +3,6 @@
 
 export * from './ApiBaseUrlProvider.js';
 export { default as ApiBaseUrlProvider } from './ApiBaseUrlProvider.js';
+export * from './ApiCacheProvider.js';
 export * from './apiServices.js';
 export * from './callback.js';

--- a/packages/context/src/tests/api/api.unit.ts
+++ b/packages/context/src/tests/api/api.unit.ts
@@ -1,12 +1,15 @@
 // Copyright (c) 2023 System Automation Corporation.
 // This file is licensed under the MIT License.
 
+import { cleanup, renderHook } from '@testing-library/react';
 import axios from 'axios';
 import chai, { expect } from 'chai';
 import dirtyChai from 'dirty-chai';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { ApiServices } from '../../api/index.js';
+import React from 'react';
+import { ApiCache, ApiCacheProvider, ApiServices, useApiServices } from '../../api/index.js';
+import ApiBaseUrlProvider from '../../api/ApiBaseUrlProvider.js';
 import { paramsSerializer } from '../../api/paramsSerializer.js';
 import { assertionCallback } from '../helpers.js';
 
@@ -487,8 +490,33 @@ describe('ApiServices', () => {
     });
 
     describe('#get request caching', () => {
-        // Each test uses a unique URL path to avoid cross-test cache contamination
-        // since the inflight maps are module-level and persist across tests.
+        // Each test gets a fresh cache object via beforeEach so there is no
+        // cross-test contamination. The cache must be passed explicitly to
+        // ApiServices; without it (cache = null) no deduplication happens.
+        let cache: ApiCache;
+
+        beforeEach(() => {
+            cache = { inflightGets: new Map(), inflightTimers: new Map(), ttlMs: 200 };
+        });
+
+        it('does not deduplicate requests when no cache is provided', async () => {
+            let callCount = 0;
+
+            server.use(
+                rest.get('http://localhost/no-cache', (req, res, ctx) => {
+                    callCount++;
+
+                    return res(ctx.json(testItem));
+                }),
+            );
+
+            // Instantiated without a cache — every call goes straight to the network
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+
+            await Promise.all([services.get('/no-cache'), services.get('/no-cache')]);
+
+            expect(callCount).to.eql(2);
+        });
 
         it('concurrent requests to the same URL only make one network call', async () => {
             let callCount = 0;
@@ -501,7 +529,7 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
             const [result1, result2] = await Promise.all([services.get('/concurrent'), services.get('/concurrent')]);
 
             expect(callCount).to.eql(1);
@@ -509,7 +537,7 @@ describe('ApiServices', () => {
             expect(result2).to.eql(testItem);
         });
 
-        it('concurrent requests from different instances with the same baseURL share the in-flight request', async () => {
+        it('concurrent requests from different instances sharing the same cache only make one network call', async () => {
             let callCount = 0;
 
             server.use(
@@ -520,8 +548,8 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services1 = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
-            const services2 = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const services1 = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
+            const services2 = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
             const [result1, result2] = await Promise.all([
                 services1.get('/concurrent-instances'),
                 services2.get('/concurrent-instances'),
@@ -543,7 +571,7 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
 
             await services.get('/ttl-hit');
             const result = await services.get('/ttl-hit');
@@ -563,7 +591,7 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
 
             await services.get('/ttl-miss');
             expect(callCount).to.eql(1);
@@ -585,7 +613,7 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
 
             await services.get('/ttl-extend');
             expect(callCount).to.eql(1);
@@ -617,7 +645,7 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
 
             try {
                 await services.get('/fail');
@@ -650,7 +678,7 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
 
             await Promise.all([services.get('/cache-url1'), services.get('/cache-url2')]);
 
@@ -673,7 +701,11 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/', paramsSerializer }));
+            const services = new ApiServices(
+                axios.create({ baseURL: 'http://localhost/', paramsSerializer }),
+                undefined,
+                cache,
+            );
 
             await Promise.all([
                 services.get('/paged', { params: { page: '1' } }),
@@ -695,7 +727,11 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/', paramsSerializer }));
+            const services = new ApiServices(
+                axios.create({ baseURL: 'http://localhost/', paramsSerializer }),
+                undefined,
+                cache,
+            );
 
             const [result1, result2] = await Promise.all([
                 services.get('/paged-shared', { params: { page: '1' } }),
@@ -718,7 +754,7 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
             const customSerializer = () => 'page=1';
 
             await Promise.all([
@@ -740,7 +776,7 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
             const customSerializer = { serialize: () => 'page=1' };
 
             await Promise.all([
@@ -762,7 +798,7 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
             const customSerializer = { encode: (param: string) => encodeURIComponent(param).toUpperCase() };
 
             await Promise.all([
@@ -796,13 +832,92 @@ describe('ApiServices', () => {
                 }),
             );
 
-            const services1 = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
-            const services2 = new ApiServices(axios.create({ baseURL: 'http://otherhost/' }));
+            const services1 = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
+            const services2 = new ApiServices(axios.create({ baseURL: 'http://otherhost/' }), undefined, cache);
 
             await Promise.all([services1.get('/same-path'), services2.get('/same-path')]);
 
             expect(host1Count).to.eql(1);
             expect(host2Count).to.eql(1);
+        });
+    });
+
+    describe('ApiCacheProvider', () => {
+        afterEach(() => {
+            cleanup();
+        });
+
+        it('provides a stable cache reference so useApiServices is not recreated on re-renders', () => {
+            // ApiCacheProvider uses useRef internally, so value={cache.current} is always
+            // the same object reference across renders. This means useApiServices' useMemo
+            // (which depends on [authContext, baseURL, cache]) won't recompute when the
+            // provider's parent re-renders, keeping the ApiServices instance stable.
+            const wrapper = ({ children }: { children: React.ReactNode }) =>
+                React.createElement(
+                    ApiBaseUrlProvider,
+                    { url: 'http://localhost/' },
+                    React.createElement(ApiCacheProvider, null, children),
+                );
+
+            const { result, rerender } = renderHook(() => useApiServices(), { wrapper });
+            const firstInstance = result.current;
+
+            rerender();
+
+            expect(result.current).to.equal(firstInstance);
+        });
+
+        it('respects a custom ttlMs prop', async () => {
+            let callCount = 0;
+
+            server.use(
+                rest.get('http://localhost/custom-ttl', (req, res, ctx) => {
+                    callCount++;
+
+                    return res(ctx.json(testItem));
+                }),
+            );
+
+            // Use a very short TTL so we can confirm it expires quickly
+            const shortCache: ApiCache = { inflightGets: new Map(), inflightTimers: new Map(), ttlMs: 50 };
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, shortCache);
+
+            await services.get('/custom-ttl');
+            expect(callCount).to.eql(1);
+
+            // Within the 50ms window — should reuse cached response
+            const result = await services.get('/custom-ttl');
+            expect(callCount).to.eql(1);
+            expect(result).to.eql(testItem);
+
+            // Wait past the 50ms TTL
+            await new Promise((resolve) => setTimeout(resolve, 100));
+
+            await services.get('/custom-ttl');
+            expect(callCount).to.eql(2);
+        });
+
+        it('each ApiCacheProvider instance has its own isolated cache', async () => {
+            let callCount = 0;
+
+            server.use(
+                rest.get('http://localhost/isolated', (req, res, ctx) => {
+                    callCount++;
+
+                    return res(ctx.json(testItem));
+                }),
+            );
+
+            const cache1: ApiCache = { inflightGets: new Map(), inflightTimers: new Map(), ttlMs: 200 };
+            const cache2: ApiCache = { inflightGets: new Map(), inflightTimers: new Map(), ttlMs: 200 };
+
+            const services1 = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache1);
+            const services2 = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache2);
+
+            // Two instances with separate caches — each makes its own network call
+            await Promise.all([services1.get('/isolated'), services2.get('/isolated')]);
+
+            expect(callCount).to.eql(2);
         });
     });
 


### PR DESCRIPTION
This pull request introduces a new `ApiCacheProvider` and refactors the `ApiServices` caching logic to support dependency injection and improved testability. The caching mechanism for GET requests is now context-based, allowing for isolated and configurable caches per provider instance. Tests are updated and expanded to cover the new behavior, including cache isolation, TTL configuration, and provider integration.

### Core caching improvements

* Introduced `ApiCacheProvider` and `useApiCache` to provide and consume an `ApiCache` context, enabling dependency injection of cache state and configuration [[1]](diffhunk://#diff-5b12dc346c3ff87b59b0b6d0b966dc3723270ee071650406df322895d7da0c85R1-R31) [[2]](diffhunk://#diff-5e04944b7db2e1bfbba32325f265f598bf26a4a6385bc1c3d79b3896399e229cR6).
* Refactored `ApiServices` to accept an optional `ApiCache` instance, removing the previous module-level singleton cache and supporting per-instance or per-provider cache isolation [[1]](diffhunk://#diff-44c8ffd786018d94ea0a063d3b0cf1a0e55b81a7a3b1d7191b59f71a333f15ccR9-R23) [[2]](diffhunk://#diff-44c8ffd786018d94ea0a063d3b0cf1a0e55b81a7a3b1d7191b59f71a333f15ccL45-R44) [[3]](diffhunk://#diff-44c8ffd786018d94ea0a063d3b0cf1a0e55b81a7a3b1d7191b59f71a333f15ccL55-R53) [[4]](diffhunk://#diff-44c8ffd786018d94ea0a063d3b0cf1a0e55b81a7a3b1d7191b59f71a333f15ccL89-L98) [[5]](diffhunk://#diff-44c8ffd786018d94ea0a063d3b0cf1a0e55b81a7a3b1d7191b59f71a333f15ccR236-R240).

### Testing and verification

* Updated and expanded unit tests to verify cache deduplication, TTL expiry, cache isolation, and integration with the new provider [[1]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L490-R519) [[2]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L504-R540) [[3]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L523-R552) [[4]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L546-R574) [[5]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L566-R594) [[6]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L588-R616) [[7]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L620-R648) [[8]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L653-R681) [[9]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L676-R708) [[10]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L698-R734) [[11]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L721-R757) [[12]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L743-R779) [[13]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L765-R801) [[14]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139L799-R836) [[15]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139R845-R923).

### API and usage changes

* Exported `ApiCacheProvider`, `ApiCache`, and `useApiCache` from the API index for easy access.
* Updated `useApiServices` to consume the cache context, ensuring that the `ApiServices` instance is stable across re-renders when used within a provider [[1]](diffhunk://#diff-44c8ffd786018d94ea0a063d3b0cf1a0e55b81a7a3b1d7191b59f71a333f15ccR236-R240) [[2]](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139R845-R923).

These changes make the API caching system more flexible, testable, and suitable for applications with multiple or isolated cache requirements.