### PR TITLE
feat(CDR-3023): add per-request cache bypass and make cache non-enumerable

### DIFF
--- a/packages/context/src/api/apiServices.ts
+++ b/packages/context/src/api/apiServices.ts
@@ -12,6 +12,12 @@ import { paramsSerializer } from './paramsSerializer.js';
 
 export type Data = Record<string, unknown> | FormData | File;
 
+/** GET-specific request config. Extends AxiosRequestConfig with caching options. */
+export type GetRequestConfig<D = Data> = AxiosRequestConfig<D> & {
+    /** Set to `false` to skip the in-flight cache for this request. */
+    cache?: false;
+};
+
 const sessionId = uuidv4();
 
 export class ApiServices {
@@ -22,6 +28,10 @@ export class ApiServices {
         authContext?: AuthenticationContext,
         private cache: ApiCache | null = null,
     ) {
+        // Hidden from enumeration so that internal cache mutations are not visible
+        // to libraries that compare or clone objects by their enumerable properties.
+        // TypeScript has already assigned this.cache above; we just change its descriptor.
+        Object.defineProperty(this, 'cache', { value: cache, enumerable: false, writable: true, configurable: true });
         this.authId = authContext?.account.id ?? 'anon';
 
         this.api.interceptors.request.use(async (config) => {
@@ -69,35 +79,39 @@ export class ApiServices {
         );
     }
 
-    get<T, D = Data>(url: string, config?: AxiosRequestConfig<D>): Promise<T>;
+    get<T, D = Data>(url: string, config?: GetRequestConfig<D>): Promise<T>;
     get<T>(url: string, cb: Callback<T>): void;
-    get<T, D = Data>(url: string, config: AxiosRequestConfig<D>, cb: Callback<T>): void;
+    get<T, D = Data>(url: string, config: GetRequestConfig<D>, cb: Callback<T>): void;
 
-    async get<T, D>(url: string, configOrCallback?: AxiosRequestConfig<D> | Callback<T>, cb?: Callback<T>) {
-        let config: AxiosRequestConfig<D> | undefined;
+    async get<T, D>(url: string, configOrCallback?: GetRequestConfig<D> | Callback<T>, cb?: Callback<T>) {
+        let config: GetRequestConfig<D> | undefined;
 
         if (cb) {
-            config = configOrCallback as AxiosRequestConfig<D>;
+            config = configOrCallback as GetRequestConfig<D>;
         } else if (typeof configOrCallback === 'function') {
             cb = configOrCallback;
         } else {
             config = configOrCallback;
         }
 
-        // Bypass cache when a custom paramsSerializer is provided since we can't guarantee that it will produce the same result
-        if (!this.cache || config?.paramsSerializer) {
-            return this.promiseOrCallback(this.api.get<T, AxiosResponse<T, D>>(url, config), cb);
+        // Strip `cache` before forwarding to axios — it is an Evoke-only option.
+        const { cache: cacheFlag, ...axiosConfig } = config ?? {};
+
+        // Bypass cache when explicitly disabled or when a custom paramsSerializer is
+        // provided (can't guarantee it produces a stable cache key).
+        if (!this.cache || cacheFlag === false || axiosConfig.paramsSerializer) {
+            return this.promiseOrCallback(this.api.get<T, AxiosResponse<T, D>>(url, axiosConfig), cb);
         }
 
         const { inflightGets, inflightTimers } = this.cache;
 
         // create unique cache key for the request based on the full URL (including baseURL) and serialized params
-        const paramStr = config?.params ? paramsSerializer(config.params) : '';
+        const paramStr = axiosConfig.params ? paramsSerializer(axiosConfig.params) : '';
         const cacheKey = `${this.authId}|${this.api.defaults.baseURL ?? ''}|${url}|${paramStr}`;
         let request = inflightGets.get(cacheKey) as Promise<AxiosResponse<T, D>> | undefined;
 
         if (!request) {
-            request = this.api.get<T, AxiosResponse<T, D>>(url, config);
+            request = this.api.get<T, AxiosResponse<T, D>>(url, axiosConfig);
             inflightGets.set(cacheKey, request);
             request.then(
                 () => this.resetDeleteTimer(cacheKey, request as Promise<AxiosResponse<unknown>>),

--- a/packages/context/src/tests/api/api.unit.ts
+++ b/packages/context/src/tests/api/api.unit.ts
@@ -787,6 +787,53 @@ describe('ApiServices', () => {
             expect(callCount).to.eql(2);
         });
 
+        it('bypasses cache when cache: false is set on the request config', async () => {
+            let callCount = 0;
+
+            server.use(
+                rest.get('http://localhost/no-cache-flag', (req, res, ctx) => {
+                    callCount++;
+
+                    return res(ctx.json(testItem));
+                }),
+            );
+
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
+
+            await Promise.all([
+                services.get('/no-cache-flag', { cache: false }),
+                services.get('/no-cache-flag', { cache: false }),
+            ]);
+
+            expect(callCount).to.eql(2);
+        });
+
+        it('cache: false only affects the flagged request, not other requests to the same URL', async () => {
+            let callCount = 0;
+
+            server.use(
+                rest.get('http://localhost/selective-cache', (req, res, ctx) => {
+                    callCount++;
+
+                    return res(ctx.json(testItem));
+                }),
+            );
+
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
+
+            // First request — cached
+            await services.get('/selective-cache');
+            expect(callCount).to.eql(1);
+
+            // Second request — cache bypassed, goes to network
+            await services.get('/selective-cache', { cache: false });
+            expect(callCount).to.eql(2);
+
+            // Third request — normal, still within TTL, should reuse cached response
+            await services.get('/selective-cache');
+            expect(callCount).to.eql(2);
+        });
+
         it('bypasses cache when a ParamsSerializerOptions object with encode is provided', async () => {
             let callCount = 0;
 
@@ -918,6 +965,64 @@ describe('ApiServices', () => {
             await Promise.all([services1.get('/isolated'), services2.get('/isolated')]);
 
             expect(callCount).to.eql(2);
+        });
+    });
+
+    describe('cache property descriptor', () => {
+        it('cache is non-enumerable when constructed without a cache', () => {
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }));
+            const descriptor = Object.getOwnPropertyDescriptor(services, 'cache');
+
+            expect(descriptor).to.exist();
+            expect(descriptor!.enumerable).to.be.false();
+        });
+
+        it('cache is non-enumerable when constructed with a cache', () => {
+            const cache: ApiCache = { inflightGets: new Map(), inflightTimers: new Map(), ttlMs: 200 };
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
+            const descriptor = Object.getOwnPropertyDescriptor(services, 'cache');
+
+            expect(descriptor).to.exist();
+            expect(descriptor!.enumerable).to.be.false();
+        });
+
+        it('cache does not appear in enumerable keys', () => {
+            const cache: ApiCache = { inflightGets: new Map(), inflightTimers: new Map(), ttlMs: 200 };
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
+
+            expect(Object.keys(services)).to.not.include('cache');
+        });
+
+        it('cache is not included when the instance is spread', () => {
+            const cache: ApiCache = { inflightGets: new Map(), inflightTimers: new Map(), ttlMs: 200 };
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
+            const spread = { ...services };
+
+            expect(Object.prototype.hasOwnProperty.call(spread, 'cache')).to.be.false();
+        });
+
+        it('cache still functions correctly after being made non-enumerable', async () => {
+            let callCount = 0;
+
+            server.use(
+                rest.get('http://localhost/non-enumerable-cache', (req, res, ctx) => {
+                    callCount++;
+
+                    return res(ctx.json(testItem));
+                }),
+            );
+
+            const cache: ApiCache = { inflightGets: new Map(), inflightTimers: new Map(), ttlMs: 200 };
+            const services = new ApiServices(axios.create({ baseURL: 'http://localhost/' }), undefined, cache);
+
+            const [result1, result2] = await Promise.all([
+                services.get('/non-enumerable-cache'),
+                services.get('/non-enumerable-cache'),
+            ]);
+
+            expect(callCount).to.eql(1);
+            expect(result1).to.eql(testItem);
+            expect(result2).to.eql(testItem);
         });
     });
 


### PR DESCRIPTION
This pull request enhances the caching behavior and API ergonomics of the `ApiServices` class. The main improvements are the addition of a `cache: false` option to bypass the in-flight cache for individual GET requests, and ensuring the internal `cache` property is non-enumerable to prevent accidental exposure or mutation by external libraries. Comprehensive tests have been added to verify these behaviors.

**Caching and Request Options:**

* Introduced a new `GetRequestConfig` type that extends `AxiosRequestConfig` with an optional `cache` property, allowing callers to set `cache: false` to bypass the cache for specific GET requests. (`packages/context/src/api/apiServices.ts`, [packages/context/src/api/apiServices.tsR15-R20](diffhunk://#diff-44c8ffd786018d94ea0a063d3b0cf1a0e55b81a7a3b1d7191b59f71a333f15ccR15-R20))
* Updated the `get` method in `ApiServices` to support the new `cache` option, ensuring requests with `cache: false` or a custom `paramsSerializer` bypass the cache. (`packages/context/src/api/apiServices.ts`, [packages/context/src/api/apiServices.tsL72-R114](diffhunk://#diff-44c8ffd786018d94ea0a063d3b0cf1a0e55b81a7a3b1d7191b59f71a333f15ccL72-R114))
* Added tests to verify that requests with `cache: false` are not cached, and that the cache bypass only affects the flagged request, not others to the same URL. (`packages/context/src/tests/api/api.unit.ts`, [packages/context/src/tests/api/api.unit.tsR790-R836](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139R790-R836))

**Internal Property Visibility:**

* Modified the `ApiServices` constructor to make the `cache` property non-enumerable, preventing it from appearing in object enumerations, spreads, or clones, while retaining its functionality. (`packages/context/src/api/apiServices.ts`, [packages/context/src/api/apiServices.tsR31-R34](diffhunk://#diff-44c8ffd786018d94ea0a063d3b0cf1a0e55b81a7a3b1d7191b59f71a333f15ccR31-R34))
* Added tests to confirm the non-enumerability of the `cache` property and that it remains functional for caching after this change. (`packages/context/src/tests/api/api.unit.ts`, [packages/context/src/tests/api/api.unit.tsR971-R1028](diffhunk://#diff-11a2760f22a9cb5feb5771bdeb86e83c9a0aaaee8cc54e6146fae91e36619139R971-R1028))